### PR TITLE
Fixing bashrc to allow ros environment for fetch run commands

### DIFF
--- a/resources/robot_skeleton/.bashrc
+++ b/resources/robot_skeleton/.bashrc
@@ -2,9 +2,6 @@
 # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
 # for examples
 
-# If not running interactively, don't do anything
-[ -z "$PS1" ] && return
-
 # Load all files from .shell/bashrc.d directory
 if [ -d $HOME/.bashrc.d ]; then
   for file in $HOME/.bashrc.d/*.sh; do


### PR DESCRIPTION
The early exit for non-interactive shells was preventing fetch run
commands from having the appropriate environment setup to use ROS.
This change removes it.