### PR TITLE
No longer defaults to debug builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ To synchronize and then run `catkin_make --pkg follow_pick
 -DCMAKE_BUILD_TYPE=Debug` to build:
 
 ```
-fetch push --no-debug --build "--pkg follow_pick -DCMAKE_BUILD_TYPE=RELEASE"
+fetch push --build "--pkg follow_pick -DCMAKE_BUILD_TYPE=RELEASE"
 ```
 
 ### fetch pull

--- a/src/fetch_tools/commands/pull.py
+++ b/src/fetch_tools/commands/pull.py
@@ -53,8 +53,8 @@ def main(args):
     if args.build is not None:
         for build in args.build:
             build = build if build is not None else ""
-            if not args.no_debug:
-                build += " -DCMAKE_BUILD_TYPE=Debug"
+            if args.build_type != "default":
+                build += " -DCMAKE_BUILD_TYPE="+args.build_type
             command = "source /opt/ros/" + os.getenv("ROS_DISTRO") + \
                       "/setup.bash && cd " + args.workspace + \
                       " && catkin_make " + build
@@ -71,7 +71,8 @@ def add_arguments(parser):
                         help="Install dependencies using rosdep")
     parser.add_argument("--build", nargs="?", action="append",
                         help="Build after syncing")
-    parser.add_argument("--no-debug", action="store_true",
-                        help="Don't build with `-DCMAKE_BUILD_TYPE=Debug`")
+    parser.add_argument("--build-type", action="store", default="default",
+                        choices=["Debug", "Release", "RelWithDebInfo", "MinSizeRel", "default"],
+                        help="Type of build to use `default`, `Debug`, `Release`, and `RelWithDebInfo`")
     parser.add_argument("--no-safety", action="store_true",
                         help="Don't prompt about overwriting the local workspace")

--- a/src/fetch_tools/commands/push.py
+++ b/src/fetch_tools/commands/push.py
@@ -49,8 +49,8 @@ def main(args):
     if args.build is not None:
         for build in args.build:
             build = build if build is not None else ""
-            if not args.no_debug:
-                build += " -DCMAKE_BUILD_TYPE=Debug"
+            if args.build_type != "default":
+                build += " -DCMAKE_BUILD_TYPE="+args.build_type
             command = "source /opt/ros/" + os.getenv("ROS_DISTRO") + \
                       "/setup.bash && cd " + args.remote_workspace + \
                       " && catkin_make " + build
@@ -67,5 +67,6 @@ def add_arguments(parser):
                         help="Install dependencies using rosdep")
     parser.add_argument("--build", nargs="?", action="append",
                         help="Build after syncing")
-    parser.add_argument("--no-debug", action="store_true",
-                        help="Don't build with `-DCMAKE_BUILD_TYPE=Debug`")
+    parser.add_argument("--build-type", action="store", default="default",
+                        choices=["Debug", "Release", "RelWithDebInfo", "MinSizeRel", "default"],
+                        help="Type of build to use `default`, `Debug`, `Release`, and `RelWithDebInfo`")


### PR DESCRIPTION
Defaulting to debug was a mistake, instead, this provides an option that
makes it easy to change the build type to debug (or anything else) with
tab completion.