### PR TITLE
Update robot.log path

### DIFF
--- a/src/fetch_tools/commands/debug_snapshot.py
+++ b/src/fetch_tools/commands/debug_snapshot.py
@@ -79,7 +79,7 @@ def main(args):
     # all commands requiring sudo must prepend this
     sudostr = "echo %s | sudo -S " % args.fetch_password[-1]
 
-    commands.update({"robot_log":sudostr + "cat /var/log/robot.log"})
+    commands.update({"robot_log":sudostr + "cat /var/log/ros/robot.log"})
 
     print('Running debug snapshot tool.')
     dirpath = tempfile.mkdtemp()


### PR DESCRIPTION
Not sure if it's just this way on our robot, but this file seems to be in subdirectory by default in melodic. Our debug snapshots were just producing "no such file" errors for that command.